### PR TITLE
Bug-fix(Config): Deleting farmer client config file when re config called solved

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -44,16 +44,16 @@ func Get(name string) string {
 }
 
 func Reconfigure() {
+	fmt.Print("Farmer API Server URL: ")
+	fmt.Scanln(&farmerConfig.ServerUrl)
+	farmerConfig.ServerUrl = strings.TrimRight(farmerConfig.ServerUrl, "/")
+
 	fo, err := os.Create(configPath)
 	defer fo.Close()
 
 	if err != nil {
 		panic(err)
 	}
-
-	fmt.Print("Farmer API Server URL: ")
-	fmt.Scanln(&farmerConfig.ServerUrl)
-	farmerConfig.ServerUrl = strings.TrimRight(farmerConfig.ServerUrl, "/")
 
 	err = toml.NewEncoder(fo).Encode(&farmerConfig)
 	if err != nil {


### PR DESCRIPTION
If someone call `farmer-cli reconfig` then truncate the command for example with `CTRL + C` then config file delete immediately. I solved it to delete and create it  after inputting new configs.
